### PR TITLE
Require HOSTNAME in env and set hostname before GPG setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+HOSTNAME=b2-host-01
 BACKUP_HOST=backup.local
 PUBLIC_IP=192.168.1.1
 GPG_PASSPHRASE=your-passphrase-here

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The `./install.sh` script :
 The script expects a `.env` file with the following values (exported as environment variables):
 
 ```env
+HOSTNAME=b2-host-01
 ADMIN_HOST=admin.local
 BACKUP_HOST=backup.local
 STATS_HOST=stats.local
@@ -52,6 +53,9 @@ GPG_PASSPHRASE=your-passphrase-here
 ROOT_PASSWORD=your-root-password
 ```
 **Variables**:
+
+- **`HOSTNAME`**  
+  Identifier/name of the host (required).
 
 - **`ADMIN_HOST`**  
   Hostname or IP address of the admin host API endpoint (required).

--- a/config.sh
+++ b/config.sh
@@ -21,6 +21,7 @@ echo "Creating .env file..."
 touch "$ENV_FILE"
 
 # Prompt the user for values
+ask_and_save "HOSTNAME" "Enter the host identifier (hostname): "
 ask_and_save "BACKUP_HOST" "Enter the backup server IP address: "
 ask_and_save "PUBLIC_IP" "Enter the public IP address: "
 ask_and_save "GPG_PASSPHRASE" "Enter the GPG passphrase: "

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ print_help() {
     echo "  The file must contain the following environment variable definitions:"
     echo ""
     echo "  Variables:"
+    echo "    HOSTNAME         - Identifier/name of the host (required)"
     echo "    BACKUP_HOST      - Hostname or IP address of the backup host API endpoint (required)"
     echo "    GPG_PASSPHRASE   - Passphrase for the PGP key (required)"
     echo "    PUBLIC_IP        - Fail-over / Public IPv4 address (required)"
@@ -39,6 +40,7 @@ print_help() {
     echo ""
     echo "Example of a .env file:"
     echo "  BACKUP_HOST=backup.local"
+    echo "  HOSTNAME=b2-host-01"
     echo "  GPG_PASSPHRASE=your-passphrase"
     echo "  PUBLIC_IP=192.168.1.1"
     echo "  ROOT_PASSWORD=your-root-password"
@@ -68,11 +70,6 @@ fi
 ### Env variables ###
 #####################
 
-# Define GPG mandatory constants
-GPG_NAME="$(hostname)"
-GPG_EXPIRY_DATE="0"
-GPG_EMAIL="$(hostname)@b2.host"
-
 if [ ! -f .env ]
 then
     echo ".env file is missing."
@@ -85,7 +82,7 @@ else
     # stop auto export
     set +a
 
-    REQUIRED_ENV_VARS=("GPG_PASSPHRASE" "PUBLIC_IP" "ROOT_PASSWORD" "BACKUP_HOST")
+    REQUIRED_ENV_VARS=("HOSTNAME" "GPG_PASSPHRASE" "PUBLIC_IP" "ROOT_PASSWORD" "BACKUP_HOST")
 
     for var in "${REQUIRED_ENV_VARS[@]}"; do
         if [[ -z "${!var}" ]]; then
@@ -94,6 +91,14 @@ else
         fi
     done
 fi
+
+# Set hostname before generating GPG key material
+./scripts/set_hostname.sh "$HOSTNAME"
+
+# Define GPG mandatory constants
+GPG_NAME="$(hostname)"
+GPG_EXPIRY_DATE="0"
+GPG_EMAIL="$(hostname)@b2.host"
 
 
 ########################


### PR DESCRIPTION
### Motivation
- Prevent GPG key generation failures caused by an unsuitable default system hostname by requiring an explicit host identifier and applying it early in the installer.

### Description
- Add `HOSTNAME` to the `install.sh` help text and to the list of required environment variables.
- Call `./scripts/set_hostname.sh "$HOSTNAME"` in `install.sh` before deriving `GPG_NAME`/`GPG_EMAIL` so GPG identity values are based on the chosen hostname.
- Update `config.sh` to prompt for `HOSTNAME` when interactively creating `.env`.
- Update `.env.example` and `README.md` to include `HOSTNAME` and document its use.

### Testing
- Ran a shell syntax check with `bash -n install.sh config.sh scripts/set_hostname.sh`, which completed without errors.
- No other automated tests were changed or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c6ab9d2b4c83259271900d1a74bf9a)