### PR TITLE
Validate Linux username length when creating instances

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -98,7 +98,7 @@ Create a new instance.
 
 | key            | required |     default      | values                 | Note                                                         |
 | -------------- | :------: | :--------------: | ---------------------- | ------------------------------------------------------------ |
-| USERNAME       |   true   |                  |                        | Name of the instance. Must be a valid domain name.           |
+| USERNAME       |   true   |                  |                        | Name of the instance. Must be a valid domain name and cannot exceed 32 characters (Linux username limit).           |
 | PASSWORD       |   true   |                  |                        | Password for all accesses (Must be at least 8 characters long). |
 | INSTANCE_TYPE  |  false   |      equal       | equal \| wordpress \| equalpress \| symbiose | Defines which instance stack template to use. |
 | CIPHER_KEY     |  false   |                  |                        | The default value is a 32 characters long randomly generated key. |

--- a/doc/cli-memo.md
+++ b/doc/cli-memo.md
@@ -71,7 +71,7 @@ Example:
 
 ### `/instance/create`
 - **Required parameters**:
-  - `USERNAME` *(string)*: instance FQDN.
+  - `USERNAME` *(string)*: instance FQDN (max 32 characters due to Linux username limit).
   - `PASSWORD` *(string)*: 8 to 70 characters.
 - **Optional parameters**:
   - `CIPHER_KEY` *(string)*: exactly 32 characters.

--- a/src/controllers/instance/create.php
+++ b/src/controllers/instance/create.php
@@ -46,8 +46,16 @@ function instance_create(array $data): array {
 
     // check params validity
 
-    if( !is_string($data['USERNAME']) || empty($data['USERNAME']) || strlen($data['USERNAME']) > 32
-        || preg_match('/^(?!\-)(?:[a-zA-Z0-9\-]{1,63}\.)+[a-zA-Z]{2,}$/', $data['USERNAME']) === 0 ) {
+    if(!is_string($data['USERNAME']) || empty($data['USERNAME'])) {
+        throw new InvalidArgumentException("invalid_USERNAME", 400);
+    }
+
+    // Linux user names are limited to 32 characters.
+    if(strlen($data['USERNAME']) > 32) {
+        throw new InvalidArgumentException("invalid_USERNAME_length", 400);
+    }
+
+    if(preg_match('/^(?!\-)(?:[a-zA-Z0-9\-]{1,63}\.)+[a-zA-Z]{2,}$/', $data['USERNAME']) === 0) {
         throw new InvalidArgumentException("invalid_USERNAME", 400);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent creating system users with names longer than the Linux limit (32 chars) which would break user creation and instance provisioning.
- Make the API and CLI docs explicit about the username length constraint to avoid operator/runtime errors.

### Description
- Added an explicit length check in `instance_create` to reject `USERNAME` values longer than 32 characters and return `invalid_USERNAME_length` (file: `src/controllers/instance/create.php`).
- Kept the existing FQDN / domain-format validation (`preg_match`) for `USERNAME` after the length check to preserve previous validation behavior (file: `src/controllers/instance/create.php`).
- Updated documentation to mention the 32-character Linux username limit in `POST /instance/create` in `doc/api.md` and the CLI memo in `doc/cli-memo.md`.

### Testing
- Ran syntax check `php -l src/controllers/instance/create.php` which returned no syntax errors (success).
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ce1dd2b6d88325a8d66e207c79b32b)